### PR TITLE
Group select reset fixed!

### DIFF
--- a/client/src/components/GraphInput.js
+++ b/client/src/components/GraphInput.js
@@ -21,8 +21,10 @@ const GraphInput = ({group1Id, setGroup1Id, group1Name, setGroup1Name,
         setGroupKey(event.target.value);
         setGroup1Id(0);
         setGroup1Name("");
+        document.getElementById("group-1").value=JSON.stringify({index: null, value:""});
         setGroup2Id(0);
         setGroup2Name("");
+        document.getElementById("group-2").value=JSON.stringify({index: null, value:""});
     }
 
     const group1Options = groupArray.map((group, index) => {
@@ -78,7 +80,6 @@ const GraphInput = ({group1Id, setGroup1Id, group1Name, setGroup1Name,
                 id="group-2"
                 type="text"
                 name="group2"
-                // value={JSON.stringify({index:group1Id, value:group2Name})}
                 defaultValue={JSON.stringify({index: null, value:""})}
                 onChange={(event) => {
                     let obj = JSON.parse(event.target.value);


### PR DESCRIPTION
Before these changes, when a new characteristic was selected the props for the selected groups were reset but the options displayed as selected by the dropdown did not reflect this. To give a cleaner user experience, this has now been fixed so the group select fields reset to their default values when a new characteristic is chosen.